### PR TITLE
[PR]feat: When a link has no heading and no display text, add the note name as the display text.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release Obsidian plugin
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+
+      - name: Build plugin
+        run: |
+          npm install
+          npm run build
+
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+
+          gh release create "$tag" \
+            --title="$tag" \
+            --draft \
+            main.js manifest.json

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "anchor-display-text",
 	"name": "Anchor Link Display Text",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"minAppVersion": "0.15.0",
 	"description": "Automatically uses the linked heading as the display text for the anchor links.",
 	"author": "Robert C Arsenault",


### PR DESCRIPTION
If the user sets it in Obsidian as
<img width="732" height="80" alt="PixPin_2025-12-18_11-39-01" src="https://github.com/user-attachments/assets/d50f3fc7-3b22-4c7d-bb22-e716b6df820b" />


Here's what might happen:

<img width="953" height="350" alt="PixPin_2025-12-18_11-40-41" src="https://github.com/user-attachments/assets/e44e239c-346c-48a0-8f92-812592cb4ce4" />

Links may contain long relative paths, which can make the text less readable. To address this, I've added an "auto alias note links" feature. When no #chapter is specified, it automatically uses the note name as the display text.

When this feature is turned on, it'll look like this:
<img width="781" height="155" alt="PixPin_2025-12-18_11-43-23" src="https://github.com/user-attachments/assets/e000f551-7e7a-4716-9737-94da72bde571" />
